### PR TITLE
Update btcz.json

### DIFF
--- a/coins/btcz.json
+++ b/coins/btcz.json
@@ -10,7 +10,7 @@
     "requireShielding": true,
     "payFoundersReward": true,
     "percentFoundersReward": 5,
-    "foundersRewardAddressChangeInterval": 14000,
+    "foundersRewardAddressChangeInterval": 14001,
     "maxFoundersRewardBlockHeight": 1400000,
     "vFoundersRewardAddress": [
      "t3eC2B44yVkyj7Q7RMkfBhkDisc4ieYtv5d",


### PR DESCRIPTION
from bitcoinz C++ code:

// Block height must be >0 and <=last founders reward block height // Index variable i ranges from 0 - (vCommunityFeeAddress.size()-1)

.....

int preBlossomMaxHeight = GetLastCommunityFeeBlockHeight(); size_t addressChangeInterval = (preBlossomMaxHeight + vCommunityFeeAddress.size()) / vCommunityFeeAddress.size(); size_t i = nHeight / addressChangeInterval;
return vCommunityFeeAddress[i];

where:

GetLastCommunityFeeBlockHeight() = 1400000
vCommunityFeeAddress.size() = 100
nHeight = height of the block (edited)

(1400000+100) / 100 = 14001

i = 1386015 / 14001 = 98.994000429 truncated to 98 because size_t is not for double numbers

vCommunityFeeAddress[98] = t3gGLesWeA25QKbb1QFNMw6NN33T6hcQAAE